### PR TITLE
Feature skip single record indexing

### DIFF
--- a/forms/elasticsearch/config.xml
+++ b/forms/elasticsearch/config.xml
@@ -14,6 +14,7 @@
 			<field name="api_call_timeout"              control="spinner"      required="true"  minValue="30" maxValue="1000" label="cms:elasticSearchControl.config.api_call_timeout.label"            help="cms:elasticSearchControl.config.api_call_timeout.help"/>
 			<field name="retry_attempts"                control="spinner"      required="true"  minValue="1"  maxValue="10"   label="cms:elasticSearchControl.config.retry_attempts.label"              help="cms:elasticSearchControl.config.retry_attempts.help"/>
 			<field name="reindex_child_pages_on_edit"   control="yesnoswitch"  required="false" default="true"                label="cms:elasticSearchControl.config.reindex_child_pages_on_edit.label" help="cms:elasticSearchControl.config.reindex_child_pages_on_edit.help"/>
+			<field name="skip_single_record_indexing"   control="yesnoswitch"  required="false" default="false"               label="cms:elasticSearchControl.config.skip_single_record_indexing.label" help="cms:elasticSearchControl.config.skip_single_record_indexing.help"/>
 		</fieldset>
 	</tab>
 </form>

--- a/i18n/cms.properties
+++ b/i18n/cms.properties
@@ -58,3 +58,6 @@ elasticsearchcontrol.config.retry_attempts.help=How many times to retry calling 
 
 elasticsearchcontrol.config.reindex_child_pages_on_edit.label=Reindex child pages on page edit
 elasticsearchcontrol.config.reindex_child_pages_on_edit.help=This is an option to stop reindex child page on edit page which could cause page timeout when there is a large number of child page to reindex
+
+elasticsearchcontrol.config.skip_single_record_indexing.label=Skip single record indexing
+elasticsearchcontrol.config.skip_single_record_indexing.help=This is an option to stop reindex individual records on insert/update. If you enable this option, then the search index will only be updated if running a full index rebuild.

--- a/interceptors/PresideExtensionElasticSearchEngineInterceptor.cfc
+++ b/interceptors/PresideExtensionElasticSearchEngineInterceptor.cfc
@@ -31,7 +31,7 @@ component extends="coldbox.system.Interceptor" {
 		}
 		var id = Len( Trim( interceptData.newId ?: "" ) ) ? interceptData.newId : ( interceptData.data.id ?: "" );
 
-		if ( Len( Trim( id ) ) ) {
+		if ( Len( Trim( id ) ) && !_skipSingleRecordIndexing() ) {
 			_getSearchEngine().indexRecord(
 				  objectName = objectName
 				, id         = id
@@ -46,7 +46,7 @@ component extends="coldbox.system.Interceptor" {
 	public void function postAddSiteTreePage( event, interceptData ) {
 		var id = interceptData.id ?: "";
 
-		if ( Len( Trim( id ) ) ) {
+		if ( Len( Trim( id ) ) && !_skipSingleRecordIndexing() ) {
 			_getSearchEngine().indexRecord(
 				  objectName = interceptData.page_type ?: ""
 				, id         = id
@@ -67,7 +67,7 @@ component extends="coldbox.system.Interceptor" {
 		var objectName = interceptData.objectName ?: "";
 		var id = Len( Trim( interceptData.id ?: "" ) ) ? interceptData.id : ( interceptData.data.id ?: "" );
 
-		if ( Len( Trim( objectName ) ) && Len( Trim( id ) ) ) {
+		if ( Len( Trim( objectName ) ) && Len( Trim( id ) ) && !_skipSingleRecordIndexing() ) {
 			_getSearchEngine().indexRecord(
 				  objectName = objectName
 				, id         = id
@@ -109,7 +109,7 @@ component extends="coldbox.system.Interceptor" {
 			id = id.toList();
 		}
 
-		if ( IsSimpleValue( id ) && Len( Trim( id ) ) ) {
+		if ( IsSimpleValue( id ) && Len( Trim( id ) ) && !_skipSingleRecordIndexing() ) {
 			_getSearchEngine().deleteRecord(
 				  objectName = objectName
 				, id         = id
@@ -135,5 +135,9 @@ component extends="coldbox.system.Interceptor" {
 	}
 	private boolean function _inThread() {
 		return getPageContext().hasFamily();
+	}
+	private boolean function _skipSingleRecordIndexing() {
+		var skipSingleRecordIndexing = systemConfigurationService.getSetting( "elasticsearch", "skip_single_record_indexing" );
+		return IsBoolean( skipSingleRecordIndexing ) && skipSingleRecordIndexing;
 	}
 }

--- a/tests/unit/ElasticSearchPresideObjectConfigurationReaderTest.cfc
+++ b/tests/unit/ElasticSearchPresideObjectConfigurationReaderTest.cfc
@@ -155,7 +155,7 @@ component extends="testbox.system.BaseSpec" {
 				var objectName       = "someobject";
 				var searchDataSource = "testsearchDataSource";
 
-				mockPresideObjectService.$( "getObjectAttribute" ).$args( objectName, "seachDataSource" ).$results( searchDataSource );
+				mockPresideObjectService.$( "getObjectAttribute" ).$args( objectName, "searchDataSource" ).$results( searchDataSource );
 				mockPresideObjectService.$( "getObjectAttribute", "dummy" );
 				mockPresideObjectService.$( "getObjectProperties", [] );
 				svc.$( "doesObjectHaveDataGetterMethod", false );


### PR DESCRIPTION
I created a possibility to switch off the indexing of single record on insert/update. I know that the adhoc task management introduced in 10.9 could solve the issue of errors on record insert/update as well (if ES is down or unstable for whatever reason). But because of backwards-compability as well as the general ability to just switch this off I think it would be an easy enhancement.