### PR TITLE
Hotfix 1.1.14

### DIFF
--- a/interceptors/PresideExtensionElasticSearchEngineInterceptor.cfc
+++ b/interceptors/PresideExtensionElasticSearchEngineInterceptor.cfc
@@ -121,10 +121,11 @@ component extends="coldbox.system.Interceptor" {
 				);
 			}
 		} catch( any e ) {
-			var message = e.detail ?: "";
-			var type    = e.type   ?: "";
+			var message = e.message ?: "";
+			var detail  = e.detail  ?: "";
+			var type    = e.type    ?: "";
 
-			if ( type == "database" && ( message contains "Unknown column" ) ) {
+			if ( type == "database" && ( message contains "Unknown column" || detail contains "Unknown column" ) ) {
 				return;
 			} else {
 				rethrow;


### PR DESCRIPTION
Shortened database exception from Lucee 5.2.9.31:
{
    "Detail": "",
    "Extended_Info": "",
    "Message": "Unknown column 'announcement.grumpf' in 'where clause'",
    "SQLState": "42S22"
}
And here from Lucee 5.3.2.77:
{
    "Detail": "Unknown column 'announcement.grumpf' in 'where clause'",
    "Extended_Info": "",
    "Message": "",
    "SQLState": "42S22"
}

Catching the exception and looking for a specific error failed with newer version of Lucee.