### PR TITLE
PXESEARCH-22 performance: json is text, not binary

### DIFF
--- a/services/ElasticSearchApiWrapper.cfc
+++ b/services/ElasticSearchApiWrapper.cfc
@@ -385,7 +385,7 @@ component {
 
 		while( !success && attempts < maxAttempts ) {
 			try {
-				http url=endpoints[ endpointIndex ] & arguments.uri method=arguments.method result="result" charset=_getCharset() getAsBinary="false" timeout=_getRequestTimeoutInSeconds() {
+				http url=endpoints[ endpointIndex ] & arguments.uri method=arguments.method result="result" getAsBinary="false" timeout=_getRequestTimeoutInSeconds() {
 					if ( StructKeyExists( arguments, "body" ) ) {
 						httpparam type="body" value=arguments.body;
 						httpparam type="header" name="Content-Type" value="application/json; charset=#_getCharset()#";
@@ -416,22 +416,14 @@ component {
 
 	private any function _processResult( required struct result ) {
 		var deserialized = "";
-		var errorMessage = "";
-		var jsonResponse = "";;
 
 		try {
-			if ( StructKeyExists( result, 'filecontent' ) ) {
-				jsonResponse = CharsetEncode( result.filecontent, _getCharset() );
-
-				if ( Len( Trim( jsonResponse ) ) ) {
-					deserialized = DeserializeJson( jsonResponse );
-				}
-			}
+			deserialized = DeserializeJson( result.filecontent );
 		} catch ( any e ) {
 			_throw(
 				  type    = "cfelasticsearch.api.Wrapper"
 				, message = "Could not parse result from Elastic Search Server. #e.message#."
-				, detail  = jsonResponse
+				, detail  = result.filecontent
 			);
 		}
 		if ( left( result.responseHeader.status_code ?: 500, 1 ) EQ "2" ) {

--- a/services/ElasticSearchApiWrapper.cfc
+++ b/services/ElasticSearchApiWrapper.cfc
@@ -385,7 +385,7 @@ component {
 
 		while( !success && attempts < maxAttempts ) {
 			try {
-				http url=endpoints[ endpointIndex ] & arguments.uri method=arguments.method result="result" charset=_getCharset() getAsBinary="yes" timeout=_getRequestTimeoutInSeconds() {
+				http url=endpoints[ endpointIndex ] & arguments.uri method=arguments.method result="result" charset=_getCharset() getAsBinary="false" timeout=_getRequestTimeoutInSeconds() {
 					if ( StructKeyExists( arguments, "body" ) ) {
 						httpparam type="body" value=arguments.body;
 						httpparam type="header" name="Content-Type" value="application/json; charset=#_getCharset()#";
@@ -420,7 +420,7 @@ component {
 		var jsonResponse = "";;
 
 		try {
-			if ( StructKeyExists( result, 'filecontent' ) and IsBinary( result.filecontent ) ) {
+			if ( StructKeyExists( result, 'filecontent' ) ) {
 				jsonResponse = CharsetEncode( result.filecontent, _getCharset() );
 
 				if ( Len( Trim( jsonResponse ) ) ) {
@@ -430,7 +430,7 @@ component {
 		} catch ( any e ) {
 			_throw(
 				  type    = "cfelasticsearch.api.Wrapper"
-				, message = "Could not parse result from Elastic Search Server. See detail for response."
+				, message = "Could not parse result from Elastic Search Server. #e.message#."
 				, detail  = jsonResponse
 			);
 		}


### PR DESCRIPTION
Doing some performance analysis with FusionReator on the handling of a 4.5 mb json response set, I found that the `cfhttp` call was consuming 100mb of memory, as was the `deserializeJson` step as well.

I don't know this proceessing as binary was put in place, as json is a simple text format.

With these changes FR is reporting memory usage 200mb lower than before.